### PR TITLE
Add brew, apt providers & move header references to shim

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,7 @@
 import PackageDescription
 
 let package = Package(
-    name: "CFontConfig"
+    name: "CFontConfig",
+    pkgConfig: "fontconfig",
+    providers: [.Brew("fontconfig"), .Apt("fontconfig")]
 )

--- a/module.modulemap
+++ b/module.modulemap
@@ -1,5 +1,5 @@
 module CFontConfig [system] {
-    header "/usr/include/fontconfig/fontconfig.h"
+    header "shim.h"
     link "fontconfig"
     export *
 }

--- a/shim.h
+++ b/shim.h
@@ -1,0 +1,2 @@
+#include <fontconfig/fontconfig.h>
+#include <fontconfig/fcfreetype.h>


### PR DESCRIPTION
Allows using Cairo with Swift 3.1 on macOS Sierra 10.12.4 with Homebrew.

Contains changes originally created by @astrotuna201 (kudos).